### PR TITLE
docs: streamline README and split deep-dive docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ Supported targets today:
 - EDOT Collector
 - Generic OpenTelemetry Collector
 
+## Project Description
+
+`agent-cli` is a terminal-first operational tool for understanding how telemetry is flowing through local agent pipelines and where it is failing.
+
+It combines static configuration parsing with live runtime signals so operators can:
+
+- inspect pipeline topology (`inputs/receivers -> processors -> outputs/exporters`)
+- assess normalized component health (`healthy`, `degraded`, `error`, `disabled`, `unknown`)
+- view key throughput and failure indicators (events, drops, send failures)
+- spot misconfigurations such as missing wiring or disabled/orphaned components
+- use both human-oriented terminal views (table/TUI) and machine-friendly output (`--format json`)
+
+The codebase uses a layered adapter architecture so each agent type maps into a shared pipeline model:
+
+- Elastic Agent adapter
+- EDOT adapter
+- Generic OTel adapter
+
 ## Project Status
 
 - **Merged:** Phase 0, Phase 1A, Phase 1B, Phase 1C
@@ -22,6 +40,13 @@ Prerequisites: Go `1.24+`
 ```bash
 git clone https://github.com/alvarolobato/agent-cli.git
 cd agent-cli
+make build
+./bin/agent-cli --help
+```
+
+Alternative without Make:
+
+```bash
 go build -o bin/agent-cli ./cmd/agent-cli
 ./bin/agent-cli --help
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# agent-cli
+
+`agent-cli` is a Go CLI/TUI for inspecting observability agent pipelines and health.
+
+Supported targets today:
+
+- Elastic Agent
+- EDOT Collector
+- Generic OpenTelemetry Collector
+
+## Project Status
+
+- **Merged:** Phase 0, Phase 1A, Phase 1B, Phase 1C
+- **Planned:** Phase 1D, Phase 1E, Phase 2
+
+Roadmap issue: [#2](https://github.com/alvarolobato/agent-cli/issues/2)
+
+## Install
+
+Prerequisites: Go `1.24+`
+
+```bash
+git clone https://github.com/alvarolobato/agent-cli.git
+cd agent-cli
+go build -o bin/agent-cli ./cmd/agent-cli
+./bin/agent-cli --help
+```
+
+## Quick Start
+
+```bash
+agent-cli discover
+agent-cli status
+agent-cli status --format json
+agent-cli tui
+```
+
+## Common Usage
+
+Elastic Agent:
+
+```bash
+agent-cli status --agent elastic-agent
+agent-cli status --agent elastic-agent --format json
+```
+
+EDOT:
+
+```bash
+agent-cli status --agent edot --edot-config /etc/edot/config.yaml
+```
+
+OTel:
+
+```bash
+agent-cli status --agent otel --otel-config /etc/otelcol/config.yaml
+```
+
+For full command options:
+
+```bash
+agent-cli --help
+agent-cli status --help
+agent-cli discover --help
+agent-cli tui --help
+```
+
+## Contributing
+
+1. Pick or create a scoped issue.
+2. Create a branch from `main`.
+3. Implement with tests.
+4. Run checks:
+
+```bash
+go build ./...
+go test -race ./...
+go vet ./...
+go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
+```
+
+5. Open a PR referencing the issue (`Closes #<issue-number>`).
+
+## Additional Documentation
+
+Deep-dive usage, architecture overview, troubleshooting, and implementation links:
+
+- [`docs/usage-and-troubleshooting.md`](docs/usage-and-troubleshooting.md)
+- [`architecture.md`](architecture.md)
+- [`decision-log.md`](decision-log.md)
+- [`project-requirements.md`](project-requirements.md)
+- [`AGENTS.md`](AGENTS.md)
+
+## License
+
+No license file is currently present in the repository.

--- a/docs/usage-and-troubleshooting.md
+++ b/docs/usage-and-troubleshooting.md
@@ -1,0 +1,134 @@
+# Usage and Troubleshooting
+
+This document keeps extended operational details out of the top-level `README.md`.
+
+## Architecture Snapshot
+
+`agent-cli` follows a layered model:
+
+1. CLI/TUI presentation (`internal/cli`, `internal/tui`)
+2. Shared pipeline model and health normalization (`internal/pipeline`)
+3. Agent adapters (`internal/agent/elasticagent`, `internal/agent/edot`, `internal/agent/otel`)
+4. Config + metrics collection (`internal/config`, `internal/metrics`)
+5. Output rendering (`internal/output`)
+
+See [`architecture.md`](../architecture.md) for full responsibilities and data flow.
+
+## Agent-Specific Usage
+
+### Elastic Agent
+
+```bash
+agent-cli status --agent elastic-agent
+agent-cli status --agent elastic-agent --format json
+agent-cli status --agent elastic-agent --elastic-config /opt/Elastic/Agent/elastic-agent.yml
+agent-cli status --agent elastic-agent --elastic-url http://127.0.0.1:6791
+agent-cli tui --agent elastic-agent
+```
+
+### EDOT
+
+```bash
+agent-cli status --agent edot \
+  --edot-config /etc/edot/config.yaml \
+  --edot-zpages-url http://127.0.0.1:55679 \
+  --edot-health-url http://127.0.0.1:13133/ \
+  --edot-metrics-url http://127.0.0.1:8888/metrics
+
+agent-cli tui --agent edot --edot-config /etc/edot/config.yaml
+```
+
+### Generic OTel Collector
+
+```bash
+agent-cli status --agent otel \
+  --otel-config /etc/otelcol/config.yaml \
+  --otel-zpages-url http://127.0.0.1:55679 \
+  --otel-health-url http://127.0.0.1:13133/ \
+  --otel-metrics-url http://127.0.0.1:8888/metrics
+```
+
+## TUI Keys (Current)
+
+- `q` / `ctrl+c`: quit
+- `up` / `down`: move selection
+- `r`: refresh trigger placeholder
+
+Live mode:
+
+```bash
+agent-cli tui --live --refresh 5s
+```
+
+## Troubleshooting
+
+### `status` shows only example pipeline
+
+Cause: no `--agent` was passed.
+
+Fix:
+
+```bash
+agent-cli status --agent elastic-agent
+```
+
+### `elastic agent config not found; pass --elastic-config`
+
+Cause: default config path not found on this host.
+
+Fix: pass the explicit config path.
+
+```bash
+agent-cli status --agent elastic-agent --elastic-config /path/to/elastic-agent.yml
+```
+
+### `edot config not found; pass --edot-config`
+
+Cause: EDOT requires explicit config path.
+
+Fix:
+
+```bash
+agent-cli status --agent edot --edot-config /etc/edot/config.yaml
+```
+
+### `otel config not found; pass --otel-config`
+
+Cause: OTel requires explicit config path.
+
+Fix:
+
+```bash
+agent-cli status --agent otel --otel-config /etc/otelcol/config.yaml
+```
+
+### zPages / health / metrics endpoint errors
+
+Cause: collector endpoints are disabled, bound to a different host/port, or blocked.
+
+Checks:
+
+- zPages: `http://127.0.0.1:55679` (or custom)
+- health_check: `http://127.0.0.1:13133/` (or custom)
+- metrics: `http://127.0.0.1:8888/metrics` (or custom)
+
+Fix: pass explicit URLs that match your collector config.
+
+### Integration tests are skipped
+
+Cause: integration tests require Docker and `RUN_INTEGRATION=1`.
+
+Fix:
+
+```bash
+cd test/integration
+docker compose up -d
+cd ../..
+RUN_INTEGRATION=1 go test ./test/integration/... -count=1
+```
+
+## More References
+
+- Requirements: [`project-requirements.md`](../project-requirements.md)
+- Decision history: [`decision-log.md`](../decision-log.md)
+- Active/planned specs: [GitHub issues](https://github.com/alvarolobato/agent-cli/issues)


### PR DESCRIPTION
## Summary
- streamline `README.md` to keep it focused on key project entry points (status, install, quick usage, contributing)
- add `docs/usage-and-troubleshooting.md` for deeper usage examples, architecture snapshot, and troubleshooting scenarios
- link README to the new doc plus core architecture/decision references

## Test plan
- [x] Validate markdown links and paths locally
- [x] Confirm command examples align with current CLI flags (`--help` outputs)
- [ ] No code/runtime behavior changes


Made with [Cursor](https://cursor.com)